### PR TITLE
Merge feature/adapt_mq_to_can_msg into develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 run:
 	bin/controller_bin
 
-test: test/test_mq_utils
+test: test/test_mq_utils test/test_mq_utils_read
 	./test/test_mq_utils
 	./test/test_mq_utils_read
 

--- a/inc/constants.h
+++ b/inc/constants.h
@@ -4,6 +4,6 @@
 #define SENSORS_MQ "/mq_aeb_sensors"
 #define ACTUATORS_MQ "/mq_aeb_actuators"
 #define MQ_MAX_MESSAGES 10
-#define MQ_MAX_MSG_SIZE 128
+#define MQ_MAX_MSG_SIZE sizeof(can_msg)
 
 #endif

--- a/inc/mq_utils.h
+++ b/inc/mq_utils.h
@@ -1,6 +1,7 @@
 #ifndef MQ_UTILS_H
 #define MQ_UTILS_H
 #include <mqueue.h>
+#include "dbc.h"
 
 struct mq_attr get_mq_attr();
 
@@ -10,8 +11,8 @@ mqd_t open_mq(char *mq_name);
 
 void close_mq(mqd_t mqd, char *mq_name);
 
-int read_mq(mqd_t mq_receiver, char* buffer);
+int read_mq(mqd_t mq_receiver, can_msg *msg_read);
 
-int write_mq(mqd_t mq_sender, char *msg);
+int write_mq(mqd_t mq_sender, can_msg *msg);
 
 #endif

--- a/src/mq_utils.c
+++ b/src/mq_utils.c
@@ -58,19 +58,23 @@ void close_mq(mqd_t mqd, char *mq_name)
     }
 }
 
-int read_mq(mqd_t mq_receiver, char* buffer)
+int read_mq(mqd_t mq_receiver, can_msg *msg_read)
 {
+    char buffer[MQ_MAX_MSG_SIZE];
     if (mq_receive(mq_receiver, buffer, MQ_MAX_MSG_SIZE, NULL) == (mqd_t)-1)
     {
         perror("Error receiving message");
         return -1;
     }
+    memcpy(msg_read, buffer, MQ_MAX_MSG_SIZE);
     return 0;
 }
 
-int write_mq(mqd_t mq_sender, char *msg)
+int write_mq(mqd_t mq_sender, can_msg *msg)
 {
-    if (mq_send(mq_sender, msg, strlen(msg) + 1, 0) == -1)
+    char buffer[MQ_MAX_MSG_SIZE];
+    memcpy(buffer, msg, MQ_MAX_MSG_SIZE);
+    if (mq_send(mq_sender, buffer, MQ_MAX_MSG_SIZE, 0) == -1)
     {
         perror("Error sending message. Message queue is full");
         return -1;

--- a/test/test_mq_utils.c
+++ b/test/test_mq_utils.c
@@ -37,7 +37,7 @@ void test_create_and_close_mq(void)
     TEST_ASSERT_NOT_EQUAL((mqd_t)-1, mqd);
 
     close_mq(mqd, mq_name);
-    exists = stat("/dev/mqueue/my_queue", &buffer);
+    exists = stat("/dev/mqueue/test_mq", &buffer);
     TEST_ASSERT_EQUAL(-1, exists);
 }
 

--- a/test/test_mq_utils.c
+++ b/test/test_mq_utils.c
@@ -3,17 +3,17 @@
 #include "mq_utils.h"
 #include "constants.h"
 
-void setUp(void)
+void setUp()
 {
     // set stuff up here
 }
 
-void tearDown(void)
+void tearDown()
 {
     // clean stuff up here
 }
 
-void test_get_mq_attr(void)
+void test_get_mq_attr()
 {
     struct mq_attr attr = get_mq_attr();
     TEST_ASSERT_EQUAL(O_NONBLOCK, attr.mq_flags);
@@ -22,7 +22,7 @@ void test_get_mq_attr(void)
     TEST_ASSERT_EQUAL(MQ_MAX_MSG_SIZE, attr.mq_msgsize);
 }
 
-void test_create_and_close_mq(void)
+void test_create_and_close_mq()
 {
     char *mq_name = "/test_mq";
     struct stat buffer;
@@ -41,7 +41,7 @@ void test_create_and_close_mq(void)
     TEST_ASSERT_EQUAL(-1, exists);
 }
 
-int main(void)
+int main()
 {
     UNITY_BEGIN();
     RUN_TEST(test_get_mq_attr);

--- a/test/test_mq_utils_read.c
+++ b/test/test_mq_utils_read.c
@@ -8,55 +8,72 @@
 char *mq_name = SENSORS_MQ;
 mqd_t mqd;
 
-void setUp(void)
+void setUp()
 {
     mqd = create_mq(mq_name);
 }
 
-void tearDown(void)
+void tearDown()
 {
     close_mq(mqd, mq_name);
 }
 
-void test_open_mq(void)
+void test_open_mq()
 {
     mqd_t mq_test = open_mq(mq_name);
     TEST_ASSERT_NOT_EQUAL(-1, mq_test);
 }
 
-void test_read_and_write_mq(void)
+void test_read_mq_empty_queue()
 {
-    mqd_t mq_write = open_mq(mq_name);
-    char *message = "Hello, World!";
-    write_mq(mq_write, message);
-    char buffer[MQ_MAX_MSG_SIZE];
-    read_mq(mqd, buffer);
-    TEST_ASSERT_EQUAL_STRING(message, buffer);
+    can_msg msg_read;
+    TEST_ASSERT_EQUAL(-1, read_mq(mqd, &msg_read));
 }
 
-void test_read_mq_empty_queue(void)
+void test_write_mq_full_queue()
 {
-    char buffer[MQ_MAX_MSG_SIZE] = "";
-    TEST_ASSERT_EQUAL(-1, read_mq(mqd, buffer));
-    TEST_ASSERT_EQUAL_STRING("", buffer);
-}
-
-void test_write_mq_full_queue(void)
-{
-    char *message = "Hello, World!";
+    can_msg msg_to_write = {0};
     for (int i = 0; i < MQ_MAX_MESSAGES; i++)
     {
-        write_mq(mqd, message);
+        write_mq(mqd, &msg_to_write);
     }
-    TEST_ASSERT_EQUAL(-1, write_mq(mqd, message));
+    TEST_ASSERT_EQUAL(-1, write_mq(mqd, &msg_to_write));
 }
 
-int main(void)
+void test_read_and_write_mq_empty_can_msg()
+{
+    mqd_t mq_write = open_mq(mq_name);
+    can_msg msg_to_write = {0};
+    write_mq(mq_write, &msg_to_write);
+    can_msg msg_read;
+    read_mq(mqd, &msg_read);
+    TEST_ASSERT_EQUAL(msg_to_write.identifier[0], msg_read.identifier[0]);
+}
+
+void test_read_and_write_mq_valid_can_msg()
+{
+    mqd_t mq_write = open_mq(mq_name);
+    can_msg msg = {
+        .identifier = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+        .dataFrame = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
+    };
+    write_mq(mq_write, &msg);
+    can_msg msg_read;
+    read_mq(mqd, &msg_read);
+    for (int i = 0; i < 8; i++)
+    {
+        TEST_ASSERT_EQUAL(msg.identifier[i], msg_read.identifier[i]);
+        TEST_ASSERT_EQUAL(msg.dataFrame[i], msg_read.dataFrame[i]);
+    }
+}
+
+int main()
 {
     UNITY_BEGIN();
     RUN_TEST(test_open_mq);
-    RUN_TEST(test_read_and_write_mq);
     RUN_TEST(test_read_mq_empty_queue);
     RUN_TEST(test_write_mq_full_queue);
+    RUN_TEST(test_read_and_write_mq_empty_can_msg);
+    RUN_TEST(test_read_and_write_mq_valid_can_msg);
     return UNITY_END();
 }


### PR DESCRIPTION
- change MQ_MAX_MSG_SIZE to sizeof(can_msg)
- refactor read_mq() and write_mq() functions to accept can_msg as arguments
- add tests to these functions

closes #10 