### PR TITLE
Merge feature/add_cppcheck_action into develop

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -19,10 +19,6 @@ jobs:
     - name: Install cppcheck
       run: sudo apt-get update && sudo apt-get install -y cppcheck
 
-    - name: Download MISRA Addon
-      run: |
-        wget https://raw.githubusercontent.com/danmar/cppcheck/master/addons/misra.py -P /tmp
-
     - name: Run Cppcheck with MISRA
       run: |
-        cppcheck --addon=/tmp/misra.py --suppress=missingIncludeSystem --inline-suppr --std=c99 --error-exitcode=1 src/
+        cppcheck --addon=misra -I ./inc --force --library=posix src/

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,26 @@
+name: Cppcheck MISRA
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install cppcheck
+      run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+    - name: Download MISRA Addon
+      run: |
+        wget https://raw.githubusercontent.com/danmar/cppcheck/master/addons/misra.py -P /tmp
+
+    - name: Run Cppcheck with MISRA
+      run: |
+        cppcheck --addon=/tmp/misra.py --suppress=missingIncludeSystem --inline-suppr --std=c99 --error-exitcode=1 src/

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -2,7 +2,9 @@ name: Cppcheck MISRA
 
 on:
   push:
-    branches: [ "develop" ]
+    branches:
+      - develop
+      - feature/add_cppcheck_action
   pull_request:
     branches: [ "develop" ]
 

--- a/inc/constants.h
+++ b/inc/constants.h
@@ -4,6 +4,6 @@
 #define SENSORS_MQ "/mq_aeb_sensors"
 #define ACTUATORS_MQ "/mq_aeb_actuators"
 #define MQ_MAX_MESSAGES 10
-#define MQ_MAX_MSG_SIZE sizeof(can_msg)
+#define MQ_MAX_MSG_SIZE 16
 
 #endif


### PR DESCRIPTION
- add workflow for cpp check using MISRA cppcheck standard addon
- hardcode 16 to sizeof(can_msg) in constants.h so that MISRA doesnt complain about it

closes #16 