### PR TITLE
Merge branch bugfix/fix_test_action into develop

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -2,7 +2,9 @@ name: Test CI
 
 on:
   push:
-    branches: [ "develop" ]
+    branches:
+      - develop
+      - bugfix/fix_test_action
   pull_request:
     branches: [ "develop" ]
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test:
 test_all: $(TESTS)
 	@for test in $^; do \
 		echo "\n\033[1;33mTest $$test results:\033[0m"; \
-		./$$test; \
+		./$$test || exit 1; \
 	done
 
 test/test_mq_utils: test/test_mq_utils.c src/mq_utils.c test/unity.c


### PR DESCRIPTION
- add `exit 1` on test workflow to exit when one unit test fails
- now the workflow fails as expected

![image](https://github.com/user-attachments/assets/e53c7b81-a5fc-4018-bc05-d5ab1ab8f6a3)


closes #84 